### PR TITLE
Fix compiler error

### DIFF
--- a/src/main/c/src/slf4j.c
+++ b/src/main/c/src/slf4j.c
@@ -171,7 +171,7 @@ Slf4jContext *slf4j__setup_static(JNIEnv *env, jclass jclazz)
 	return thread_context;
 }
 
-void slf4j_teardown(Slf4jContext **context)
+void slf4j_teardown(Slf4jContext **unused)
 {
 	if (thread_context == NULL)
 	{


### PR DESCRIPTION
```
src/slf4j.c: In function ‘slf4j_teardown’:
src/slf4j.c:181:16: error: ‘context’ redeclared as different kind of symbol
  Slf4jContext *context = thread_context;
                ^~~~~~~
src/slf4j.c:174:36: note: previous definition of ‘context’ was here
 void slf4j_teardown(Slf4jContext **context)
                                    ^~~~~~~
```
```
$ i686-linux-gnu-gcc --version
i686-linux-gnu-gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```