### PR TITLE
Unblock main thread if monitor thread init fails

### DIFF
--- a/src/main/c/include/SerialImp.h
+++ b/src/main/c/include/SerialImp.h
@@ -416,6 +416,7 @@ printf("%8li sec : %8li usec\n", enow.tv_sec - snow.tv_sec, enow.tv_sec - snow.t
 #define OUT_OF_MEMORY "java/lang/OutOfMemoryError"
 #define IO_EXCEPTION "java/io/IOException"
 #define PORT_IN_USE_EXCEPTION "gnu/io/PortInUseException"
+#define MONITOR_INITIALIZATION_EXCEPTION "gnu/io/MonitorInitializationException"
 
 /* some popular releases of Slackware do not have SSIZE_MAX */
 

--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -3838,7 +3838,8 @@ int lock_monitor_thread(JNIEnv *env, jobject jobj)
 }
 
 /**
- * Signal that the monitor thread is ready for work.
+ * Signal that the monitor thread has finished initialization and
+ * is either ready for work or has thrown a Java exception.
  *
  * In order to signal the condition, the current thread must already hold the
  * write lock.
@@ -3847,35 +3848,35 @@ int lock_monitor_thread(JNIEnv *env, jobject jobj)
  * @param [in] obj an RXTXPort instance
  * @return 0 on success; 1 on error
  */
-int signal_monitor_thread_ready(JNIEnv *env, jobject jobj)
+int signal_monitor_thread_init_completed(JNIEnv *env, jobject jobj)
 {
-	jfieldID monitorThreadReadyField = (*env)->GetFieldID(
+	jfieldID monitorThreadInitCompletedField = (*env)->GetFieldID(
 		env,
 		(*env)->GetObjectClass(env, jobj),
-		"monitorThreadReady",
+		"monitorThreadInitCompleted",
 		"Ljava/util/concurrent/locks/Condition;");
 	if ((*env)->ExceptionCheck(env)) {
 		return 1;
 	}
 
-	jobject monitorThreadReady = (*env)->GetObjectField(
+	jobject monitorThreadInitCompleted = (*env)->GetObjectField(
 		env,
 		jobj,
-		monitorThreadReadyField);
+		monitorThreadInitCompletedField);
 	if ((*env)->ExceptionCheck(env)) {
 		return 1;
 	}
 
 	jmethodID signal = (*env)->GetMethodID(
 		env,
-		(*env)->GetObjectClass(env, monitorThreadReady),
+		(*env)->GetObjectClass(env, monitorThreadInitCompleted),
 		"signal",
 		"()V");
 	if ((*env)->ExceptionCheck(env)) {
 		return 1;
 	}
 
-	(*env)->CallVoidMethod(env, monitorThreadReady, signal);
+	(*env)->CallVoidMethod(env, monitorThreadInitCompleted, signal);
 	if ((*env)->ExceptionCheck(env)) {
 		return 1;
 	}
@@ -4265,6 +4266,7 @@ int initialise_event_info_struct( struct event_info_struct *eis )
 	jobject jobj = *eis->jobj;
 	JNIEnv *env = eis->env;
 	struct event_info_struct *index = master_index;
+	char message[28];
 
 	if ( eis->initialised == 1 )
 		goto end;
@@ -4308,8 +4310,9 @@ int initialise_event_info_struct( struct event_info_struct *eis )
 
 	eis->send_event = (*env)->GetMethodID( env, eis->jclazz, "sendEvent",
 		"(IZ)Z" );
-	if(eis->send_event == NULL){
-		report_error("initialise_event_info_struct: eis->send_event == NULL!\n");
+	if(eis->send_event == NULL) {
+		throw_java_exception(env, MONITOR_INITIALIZATION_EXCEPTION,
+			"initialise_event_info_struct", "eis->send_event == NULL");
 		goto fail;
 	}
 end:
@@ -4320,12 +4323,15 @@ end:
 		eis->tv_sleep.tv_usec = 100 * 1000;
 		eis->initialised = 1;
 		return( 1 );
-	} else if(eis->fd >= FD_SETSIZE ){
-		// you can reduce this limitation only with migration to epool or something like that.
-		report_error("initialise_event_info_struct: eis->fd >= FD_SETSIZE!\n");
-	} else if(eis->fd <= 0 ){
-		// you can reduce this limitation only with migration to epool or something like that.
-		report_error("initialise_event_info_struct: eis->fd <= 0!\n");
+	} else if (eis->fd >= FD_SETSIZE) {
+		// you can reduce this limitation only with migration to poll or something like that.
+		sprintf(message, "fd == %i >= %i", eis->fd, FD_SETSIZE);
+		throw_java_exception(env, MONITOR_INITIALIZATION_EXCEPTION,
+			"initialise_event_info_struct", message);
+	} else if (eis->fd <= 0) {
+		sprintf(message, "fd == %i <= 0", eis->fd);
+		throw_java_exception(env, MONITOR_INITIALIZATION_EXCEPTION,
+			"initialise_event_info_struct", message);
 	}
 fail:
 	finalize_event_info_struct( eis );
@@ -4385,10 +4391,23 @@ JNIEXPORT void JNICALL RXTXPort(eventLoop)( JNIEnv *env, jobject jobj )
 	eis.initialised = 0;
 
 	ENTER( "eventLoop\n" );
+
+	/* If initialisation fails, we throw a Java exception, so the
+	 * Java main thread has a chance to learn what went wrong.
+	 * In that case, the monitor thread must notify the main thread
+	 * and release the lock to avoid blocking the main thread
+	 * indefinitely.
+	 * We must also defer the notify/unlock sequence at least until
+	 * the info that something went wrong has been made available
+	 * to the main thread (via the `pendingException` field), so that
+	 * when the main thread returns from `await`, it gets a chance
+	 * to know that it has to bail and not enter its main loop.
+	 * Due to that constraint, let the Java catch block be responsible
+	 * for the notify/unlock dance if initialisation fails. */
 	if ( !initialise_event_info_struct( &eis ) ) goto end;
 	if ( !init_threads( &eis ) ) goto end;
 
-	if (signal_monitor_thread_ready(env, jobj)) goto end;
+	if (signal_monitor_thread_init_completed(env, jobj)) goto end;
 	if (unlock_monitor_thread(env, jobj)) goto end;
 
 	do{

--- a/src/main/java/gnu/io/MonitorInitializationException.java
+++ b/src/main/java/gnu/io/MonitorInitializationException.java
@@ -1,0 +1,78 @@
+/*-------------------------------------------------------------------------
+|   RXTX License v 2.1 - LGPL v 2.1 + Linking Over Controlled Interface.
+|   RXTX is a native interface to serial ports in java.
+|   Copyright 1997-2025 by Trent Jarvi tjarvi@qbang.org and others who
+|   actually wrote it.  See individual source files for more information.
+|
+|   A copy of the LGPL v 2.1 may be found at
+|   http://www.gnu.org/licenses/lgpl.txt on March 4th 2007.  A copy is
+|   here for your convenience.
+|
+|   This library is free software; you can redistribute it and/or
+|   modify it under the terms of the GNU Lesser General Public
+|   License as published by the Free Software Foundation; either
+|   version 2.1 of the License, or (at your option) any later version.
+|
+|   This library is distributed in the hope that it will be useful,
+|   but WITHOUT ANY WARRANTY; without even the implied warranty of
+|   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+|   Lesser General Public License for more details.
+|
+|   An executable that contains no derivative of any portion of RXTX, but
+|   is designed to work with RXTX by being dynamically linked with it,
+|   is considered a "work that uses the Library" subject to the terms and
+|   conditions of the GNU Lesser General Public License.
+|
+|   The following has been added to the RXTX License to remove
+|   any confusion about linking to RXTX.   We want to allow in part what
+|   section 5, paragraph 2 of the LGPL does not permit in the special
+|   case of linking over a controlled interface.  The intent is to add a
+|   Java Specification Request or standards body defined interface in the 
+|   future as another exception but one is not currently available.
+|
+|   http://www.fsf.org/licenses/gpl-faq.html#LinkingOverControlledInterface
+|
+|   As a special exception, the copyright holders of RXTX give you
+|   permission to link RXTX with independent modules that communicate with
+|   RXTX solely through the Sun Microsytems CommAPI interface version 2,
+|   regardless of the license terms of these independent modules, and to copy
+|   and distribute the resulting combined work under terms of your choice,
+|   provided that every copy of the combined work is accompanied by a complete
+|   copy of the source code of RXTX (the version of RXTX used to produce the
+|   combined work), being distributed under the terms of the GNU Lesser General
+|   Public License plus this exception.  An independent module is a
+|   module which is not derived from or based on RXTX.
+|
+|   Note that people who make modified versions of RXTX are not obligated
+|   to grant this special exception for their modified versions; it is
+|   their choice whether to do so.  The GNU Lesser General Public License
+|   gives permission to release a modified version without this exception; this
+|   exception also makes it possible to release a modified version which
+|   carries forward this exception.
+|
+|   You should have received a copy of the GNU Lesser General Public
+|   License along with this library; if not, write to the Free
+|   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+|   All trademarks belong to their respective owners.
+--------------------------------------------------------------------------*/
+package gnu.io;
+
+/**
+* The monitor thread encountered an error while initializing the
+* event loop.
+*/
+@SuppressWarnings("serial")
+public class MonitorInitializationException extends RuntimeException
+{
+	public MonitorInitializationException(String str)
+	{
+		super(str);
+	}
+	public MonitorInitializationException()
+	{
+		super();
+	}
+	public MonitorInitializationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}


### PR DESCRIPTION
https://github.com/NeuronRobotics/nrjavaserial/pull/211/commits/e53d7b6c1746befc1d8c2fae39a2e4ea375b11de introduces a regression, which makes the main thread hang indefinitely if the monitor thread encounters an error during initialization.

The hang is caused by the monitor thread bailing without ever releasing the synchronization lock and without signaling the `Condition` on which the main thread is waiting.

This PR unblocks the main thread by adding the signal/unlock sequence to the failure path.
It also throws a Java exception and propagates it to the main thread so the caller gets to see exactly what caused the error.

I have tested this fix on the same machines where we encountered the regression. However, I haven't been able to reproduce the `fd >= FD_SETSIZE` scenario reliably, because the library usually draws `fd`s between 200 and 900 there (but it's only very occasionally that it reaches 1024). So instead of waiting for `fd >= FD_SETSIZE` to occur by itself, I used the following temporary patch as a substitute to simulate the failure:

<details><summary>Temporary patch to simulate failures</summary>

```patch
From de64aca31460124cf8fe98f1844ba06da647a952 Mon Sep 17 00:00:00 2001
From: Claudia Pellegrino <Claudia.Pellegrino-extern@deutschebahn.com>
Date: Tue, 7 Jan 2025 17:21:19 +0100
Subject: [PATCH] [TESTING] Deliberately fail six times

---
 src/main/c/src/SerialImp.c         | 12 ++++++++++++
 src/main/java/gnu/io/RXTXPort.java | 11 ++++++++---
 2 files changed, 20 insertions(+), 3 deletions(-)

diff --git a/src/main/c/src/SerialImp.c b/src/main/c/src/SerialImp.c
index 772331d..d2758b6 100644
--- a/src/main/c/src/SerialImp.c
+++ b/src/main/c/src/SerialImp.c
@@ -159,6 +159,8 @@ JavaVM *javaVM = NULL;
 
 struct preopened *preopened_port = NULL;
 
+int serial_bogus_errors_remaining = 6;
+
 /* this is so diff will not generate noise when merging 1.4 and 1.5 changes
  * It will eventually be removed.
  * */
@@ -4317,6 +4319,16 @@ int initialise_event_info_struct( struct event_info_struct *eis )
 	}
 end:
 	FD_ZERO( &eis->rfds );
+	// BEGIN temporary addition to simulate three out-of-bounds fds
+	if (serial_bogus_errors_remaining > 0) {
+		report( "initialise_event_info_struct: serial_bogus_errors_remaining > 0\n" );
+		serial_bogus_errors_remaining--;
+		snprintf(message, sizeof(message), "[BOGUS ERROR] fd == %i", eis->fd);
+		throw_java_exception(env, MONITOR_INITIALIZATION_EXCEPTION,
+			"initialise_event_info_struct", message);
+		goto fail;
+	}
+	// END temporary addition to simulate three out-of-bounds fds
 	if (eis->fd < FD_SETSIZE && eis->fd > 0) {
 		FD_SET( eis->fd, &eis->rfds );
 		eis->tv_sleep.tv_sec = 0;
diff --git a/src/main/java/gnu/io/RXTXPort.java b/src/main/java/gnu/io/RXTXPort.java
index 4615e04..7d696a6 100644
--- a/src/main/java/gnu/io/RXTXPort.java
+++ b/src/main/java/gnu/io/RXTXPort.java
@@ -149,7 +149,7 @@ public class RXTXPort extends SerialPort
 		}
 	}
 	protected boolean HARDWARE_FAULT=false;
-	protected final static boolean debug = false;
+	protected final static boolean debug = true;
 	protected final static boolean debug_read = false;
 	protected final static boolean debug_read_results = false;
 	protected final static boolean debug_write = false;
@@ -161,7 +161,7 @@ public class RXTXPort extends SerialPort
 	static
 	{
 		try {
-			z = new Zystem(Zystem.SILENT_MODE);
+			z = new Zystem(Zystem.PRINT_MODE);
 		} catch ( Exception e ) {}
 
 		if(debug ) 
@@ -198,6 +198,9 @@ public class RXTXPort extends SerialPort
 	*/
 	//	try {
 			fd = open( name );
+			if (debug) {
+				z.reportln("[DEBUG] RXTXPort(" + name + "): fd == " + fd);
+			}
 			this.name = name;
 
 			this.monitorThreadState.writeLock().lock();
@@ -213,6 +216,9 @@ public class RXTXPort extends SerialPort
 			MonitorInitializationException exception = monThread.popPendingException();
 			if (exception != null) {
 				close();
+				if (debug) {
+					z.reportln("[DEBUG] RXTXPort:RXTXPort(" + name + ") successfully closed fd");
+				}
 				throw exception;
 			}
 	//	} catch ( PortInUseException e ){}
@@ -1193,7 +1199,6 @@ public class RXTXPort extends SerialPort
 				z.reportln( "RXTXPort:calling close()");
 			close();
 		}
-		z.finalize();
 	}
 
 	/** Inner class for SerialOutputStream */
-- 
2.30.2
```

</details>

<details><summary>Test results</summary>

```log
Jan 14 13:10:31 REDACTED[57646]: RXTXPort {}
Jan 14 13:10:31 REDACTED[57646]: RXTXPort:RXTXPort(/dev/ttyUSB3) called
Jan 14 13:10:31 REDACTED[57646]: [DEBUG] RXTXPort(/dev/ttyUSB3): fd == 754
Jan 14 13:10:31 REDACTED[57646]: RXTXPort:MontitorThread:MonitorThread()
Jan 14 13:10:31 REDACTED[57646]: RXTXPort:MontitorThread:run()
Jan 14 13:10:31 REDACTED[57646]: Error while initializing monitor thread; propagating.
Jan 14 13:10:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 )
Jan 14 13:10:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 ) setting monThreadisInterrupted
Jan 14 13:10:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 ) calling nativeClose
Jan 14 13:10:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 ) calling super.close
Jan 14 13:10:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 ) leaving
Jan 14 13:10:31 REDACTED[57646]: [DEBUG] RXTXPort:RXTXPort(/dev/ttyUSB3) successfully closed fd
Jan 14 13:10:31 REDACTED[57646]: Failed to connect on port: /dev/ttyUSB3 exception:
Jan 14 13:10:31 REDACTED[57646]: gnu.io.MonitorInitializationException: [BOGUS ERROR] fd == 754 in initialise_event_info_struct
Jan 14 13:10:31 REDACTED[57646]:         at gnu.io.RXTXPort.eventLoop(Native Method)
Jan 14 13:10:31 REDACTED[57646]:         at gnu.io.RXTXPort$MonitorThread.run(RXTXPort.java:118)
Jan 14 13:10:36 REDACTED[57646]: RXTXPort:MonitorThread exiting
Jan 14 13:10:36 REDACTED[57646]: RXTXPort:finalize()
Jan 14 13:10:38 REDACTED[57646]: SLF4J(W): Class path contains multiple SLF4J providers.
Jan 14 13:10:38 REDACTED[57646]: SLF4J(W): Found provider [org.apache.logging.slf4j.SLF4JServiceProvider@6ac53794]
Jan 14 13:10:38 REDACTED[57646]: SLF4J(W): Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@2052c5b6]
Jan 14 13:10:38 REDACTED[57646]: SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
Jan 14 13:10:39 REDACTED[57646]: SLF4J(I): Actual provider is of type [org.apache.logging.slf4j.SLF4JServiceProvider@6ac53794]
Jan 14 13:11:31 REDACTED[57646]: RXTXPort:RXTXPort(/dev/ttyUSB3) called
Jan 14 13:11:31 REDACTED[57646]: [DEBUG] RXTXPort(/dev/ttyUSB3): fd == 387
Jan 14 13:11:31 REDACTED[57646]: RXTXPort:MontitorThread:MonitorThread()
Jan 14 13:11:31 REDACTED[57646]: RXTXPort:MontitorThread:run()
Jan 14 13:11:31 REDACTED[57646]: Error while initializing monitor thread; propagating.
Jan 14 13:11:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 )
Jan 14 13:11:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 ) setting monThreadisInterrupted
Jan 14 13:11:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 ) calling nativeClose
Jan 14 13:11:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 ) calling super.close
Jan 14 13:11:31 REDACTED[57646]: RXTXPort:close( /dev/ttyUSB3 ) leaving
Jan 14 13:11:31 REDACTED[57646]: [DEBUG] RXTXPort:RXTXPort(/dev/ttyUSB3) successfully closed fd
Jan 14 13:11:31 REDACTED[57646]: Failed to connect on port: /dev/ttyUSB3 exception:
Jan 14 13:11:31 REDACTED[57646]: gnu.io.MonitorInitializationException: [BOGUS ERROR] fd == 387 in initialise_event_info_struct
Jan 14 13:11:31 REDACTED[57646]:         at gnu.io.RXTXPort.eventLoop(Native Method)
Jan 14 13:11:31 REDACTED[57646]:         at gnu.io.RXTXPort$MonitorThread.run(RXTXPort.java:118)
Jan 14 13:11:32 REDACTED[57646]: RXTXPort:finalize()
Jan 14 13:11:32 REDACTED[57646]: RXTXPort:MonitorThread exiting
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:RXTXPort(/dev/ttyS0) called
Jan 14 13:11:38 REDACTED[57646]: [DEBUG] RXTXPort(/dev/ttyS0): fd == 864
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:MontitorThread:MonitorThread()
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:MontitorThread:run()
Jan 14 13:11:38 REDACTED[57646]: Error while initializing monitor thread; propagating.
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 )
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) setting monThreadisInterrupted
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) calling nativeClose
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) calling super.close
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) leaving
Jan 14 13:11:38 REDACTED[57646]: [DEBUG] RXTXPort:RXTXPort(/dev/ttyS0) successfully closed fd
Jan 14 13:11:38 REDACTED[57646]: Failed to connect on port: /dev/ttyS0 exception:
Jan 14 13:11:38 REDACTED[57646]: gnu.io.MonitorInitializationException: [BOGUS ERROR] fd == 864 in initialise_event_info_struct
Jan 14 13:11:38 REDACTED[57646]:         at gnu.io.RXTXPort.eventLoop(Native Method)
Jan 14 13:11:38 REDACTED[57646]:         at gnu.io.RXTXPort$MonitorThread.run(RXTXPort.java:118)
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:RXTXPort(/dev/ttyS0) called
Jan 14 13:11:38 REDACTED[57646]: [DEBUG] RXTXPort(/dev/ttyS0): fd == 867
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:MontitorThread:MonitorThread()
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:MontitorThread:run()
Jan 14 13:11:38 REDACTED[57646]: Error while initializing monitor thread; propagating.
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 )
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) setting monThreadisInterrupted
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) calling nativeClose
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) calling super.close
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) leaving
Jan 14 13:11:38 REDACTED[57646]: [DEBUG] RXTXPort:RXTXPort(/dev/ttyS0) successfully closed fd
Jan 14 13:11:38 REDACTED[57646]: Failed to connect on port: /dev/ttyS0 exception:
Jan 14 13:11:38 REDACTED[57646]: gnu.io.MonitorInitializationException: [BOGUS ERROR] fd == 867 in initialise_event_info_struct
Jan 14 13:11:38 REDACTED[57646]:         at gnu.io.RXTXPort.eventLoop(Native Method)
Jan 14 13:11:38 REDACTED[57646]:         at gnu.io.RXTXPort$MonitorThread.run(RXTXPort.java:118)
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:RXTXPort(/dev/ttyS0) called
Jan 14 13:11:38 REDACTED[57646]: [DEBUG] RXTXPort(/dev/ttyS0): fd == 870
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:MontitorThread:MonitorThread()
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:MontitorThread:run()
Jan 14 13:11:38 REDACTED[57646]: Error while initializing monitor thread; propagating.
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 )
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) setting monThreadisInterrupted
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) calling nativeClose
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) calling super.close
Jan 14 13:11:38 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) leaving
Jan 14 13:11:38 REDACTED[57646]: [DEBUG] RXTXPort:RXTXPort(/dev/ttyS0) successfully closed fd
Jan 14 13:11:38 REDACTED[57646]: Failed to connect on port: /dev/ttyS0 exception:
Jan 14 13:11:38 REDACTED[57646]: gnu.io.MonitorInitializationException: [BOGUS ERROR] fd == 870 in initialise_event_info_struct
Jan 14 13:11:38 REDACTED[57646]:         at gnu.io.RXTXPort.eventLoop(Native Method)
Jan 14 13:11:38 REDACTED[57646]:         at gnu.io.RXTXPort$MonitorThread.run(RXTXPort.java:118)
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:RXTXPort(/dev/ttyS0) called
Jan 14 13:11:39 REDACTED[57646]: [DEBUG] RXTXPort(/dev/ttyS0): fd == 875
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:MontitorThread:MonitorThread()
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:MontitorThread:run()
Jan 14 13:11:39 REDACTED[57646]: Error while initializing monitor thread; propagating.
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 )
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) setting monThreadisInterrupted
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) calling nativeClose
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) calling super.close
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:close( /dev/ttyS0 ) leaving
Jan 14 13:11:39 REDACTED[57646]: [DEBUG] RXTXPort:RXTXPort(/dev/ttyS0) successfully closed fd
Jan 14 13:11:39 REDACTED[57646]: Failed to connect on port: /dev/ttyS0 exception:
Jan 14 13:11:39 REDACTED[57646]: gnu.io.MonitorInitializationException: [BOGUS ERROR] fd == 875 in initialise_event_info_struct
Jan 14 13:11:39 REDACTED[57646]:         at gnu.io.RXTXPort.eventLoop(Native Method)
Jan 14 13:11:39 REDACTED[57646]:         at gnu.io.RXTXPort$MonitorThread.run(RXTXPort.java:118)
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:RXTXPort(/dev/ttyS0) called
Jan 14 13:11:39 REDACTED[57646]: [DEBUG] RXTXPort(/dev/ttyS0): fd == 878
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:MontitorThread:MonitorThread()
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:MontitorThread:run()
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:RXTXPort(/dev/ttyS0) returns with fd = 878
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:enableReceiveTimeout() called
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:enableReceiveTimeout() returning
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:setSerialPortParams(1200 8 1 0) called
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:setSerialPortParams(1200 8 1 0) returning
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:notifyOnDataAvailable( true )
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:setSerialPortParams(1200 7 2 2) called
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:setSerialPortParams(1200 7 2 2) returning
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:enableReceiveTimeout() called
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:enableReceiveTimeout() returning
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:enableReceiveThreshold( 1 ) called
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:enableReceiveThreshold( 1 ) returned
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:getInputStream() called and returning
Jan 14 13:11:39 REDACTED[57646]: RXTXPort:getOutputStream() called and returning
```

</details> 

@MrDOS Filing this PR against your bugfix branch because that's what introduces the regression. Review welcome!
